### PR TITLE
Modification of typographical errors 3

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,8 +27,7 @@
         <li> <a href="feature.html">Linux Mint の特徴</a> </li>
         <li> <a href="linuxmint.html">Linux Mint とは</a> </li>
         <li> <a href="community.html">コミュニティ</a> </li>
-        <li> <a href="http://dev.linuxmint-jp.net/index.php/%E3%83%A6%E3%83%BC%E3%82%B6%E3%83%BC%E3%82%BA%E3%82%AC%E3%82%A4%E3%83%89">ユー
-            ザーズガイド</a> </li>
+        <li> <a href="http://dev.linuxmint-jp.net/index.php/%E3%83%A6%E3%83%BC%E3%82%B6%E3%83%BC%E3%82%BA%E3%82%AC%E3%82%A4%E3%83%89">ユーザーズガイド</a> </li>
         <li> <a href="forum.html">フォーラム</a> </li>
         <li> <a href="http://wiki.linuxmint-jp.net/">wiki</a> </li>
         <li> <a href="FAQ.html">FAQ</a> </li>


### PR DESCRIPTION
index.htmlだけナビゲーションバーの「ユーザーズガイド」が「ユー ザーズガイド」(長音とザの間に半角スペースが入っている)となっていたのでソースを確認したら改行が入ってしまってた模様。
