### PR TITLE
17.3 KDE・Xfce の更新 / フッタの年を 2016 に変更

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,12 +101,12 @@
           </li>
           <li>
             <div> <img alt="Linux Mint KDE" src="images/lofthumbs/Linux_Mint_Logo.png" />
-              <h3>Linux Mint 17.2 KDE</h3>
+              <h3>Linux Mint 17.3 KDE</h3>
             </div>
           </li>
           <li>
             <div> <img alt="Linux Mint Xfce" src="images/lofthumbs/Linux_Mint_Logo.png" />
-              <h3>Linux Mint 17.2 Xfce</h3>
+              <h3>Linux Mint 17.3 Xfce</h3>
             </div>
           </li>
           <li>
@@ -156,6 +156,10 @@ setup_postdata($post);
 	</aside>
     <aside class="columnB">
       <h2>リリース情報</h2>
+      <h3>2016 1/10</h3>
+      <p>Linux Mint 17.3 "KDE" リリース!</p>
+      <h3>2016 1/10</h3>
+      <p>Linux Mint 17.3 "Xfce" リリース!</p>
       <h3>2015 12/4</h3>
       <p>Linux Mint 17.3 "Cinnamon" リリース!</p>
       <h3>2015 12/4</h3>
@@ -194,7 +198,7 @@ setup_postdata($post);
       </div>
     </aside>
     <footer>
-      <address> Copyright c 2015 Linux Mint Japan All Rights Reserved.</address>
+      <address> Copyright c 2016 Linux Mint Japan All Rights Reserved.</address>
     </footer>
   </body>
 </html>


### PR DESCRIPTION
17.3 KDE・Xfce の更新に伴う HTML 変更です。
合わせてフッタを 2016 年に更新しておきました。
（PHP を使えるので、この部分は自動更新にしておいても良いかもしれませんね）
よろしくお願いいたします。